### PR TITLE
Add support to save multiple terraform states

### DIFF
--- a/api/types/terraform.go
+++ b/api/types/terraform.go
@@ -1,13 +1,17 @@
 // Package types provides shared types and structs.
 package types
 
+import (
+	"time"
+)
+
 // Lock structure to hold terraform lock details
 type Lock struct {
-	ID        string `json:"ID" yaml:"ID"`
-	Operation string `json:"Operation" yaml:"Operation"`
-	Info      string `json:"Info" yaml:"Info"`
-	Who       string `json:"Who" yaml:"Who"`
-	Version   string `json:"Version" yaml:"Version"`
-	Created   string `json:"Vreated" yaml:"Vreated"`
-	Path      string `json:"Path" yaml:"Path"`
+	ID        string    `json:"ID" yaml:"ID"`
+	Operation string    `json:"Operation" yaml:"Operation"`
+	Info      string    `json:"Info" yaml:"Info"`
+	Who       string    `json:"Who" yaml:"Who"`
+	Version   string    `json:"Version" yaml:"Version"`
+	Created   time.Time `json:"Created" yaml:"Created"`
+	Path      string    `json:"Path" yaml:"Path"`
 }


### PR DESCRIPTION
Currently Terraform state and lock API allows to save a single entry of state and lock.
Following API changes are done to support mulitple entries of state and lock.

GET /1.0/terraformstate/<name>
PUT /1.0/terraformstate/<name>
PUT /1.0/terraformlock/<name>
PUT /1.0/terraformunlock/<name>

These changes allow to use different http backend addresses for different terraform plans.