### PR TITLE
Make nodes filterable by role

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -32,8 +32,16 @@ var nodeCmd = rest.Endpoint{
 	Delete: rest.EndpointAction{Handler: cmdNodesDelete, ProxyTarget: true},
 }
 
-func cmdNodesGetAll(s *state.State, _ *http.Request) response.Response {
-	nodes, err := sunbeam.ListNodes(s)
+func cmdNodesGetAll(s *state.State, r *http.Request) response.Response {
+	var role *string
+
+	roleParam := r.URL.Query().Get("role")
+
+	if roleParam != "" {
+		role = &roleParam
+	}
+
+	nodes, err := sunbeam.ListNodes(s, role)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/sunbeam/nodes.go
+++ b/sunbeam/nodes.go
@@ -11,13 +11,19 @@ import (
 	"github.com/openstack-snaps/sunbeam-microcluster/database"
 )
 
-// ListNodes return all the nodes
-func ListNodes(s *state.State) (types.Nodes, error) {
+// ListNodes return all the nodes, filterable by role (Optional)
+func ListNodes(s *state.State, role *string) (types.Nodes, error) {
 	nodes := types.Nodes{}
+
+	filters := make([]database.NodeFilter, 0)
+
+	if role != nil {
+		filters = append(filters, database.NodeFilter{Role: role})
+	}
 
 	// Get the nodes from the database.
 	err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
-		records, err := database.GetNodes(ctx, tx)
+		records, err := database.GetNodes(ctx, tx, filters...)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch nodes: %w", err)
 		}


### PR DESCRIPTION
The /nodes endpoints now takes a query param `role` to filter its response implemented as follow:
  * A missing role param returns every nodes
  * A role not present in any node, return no nodes

Example:
  * /1.0/nodes?role=CONVERGED will return the list of every converged
  nodes.
  * /1.0/nodes?role=MY_ROLE, if no node with this role, will return an
  empty list.